### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on: [pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/wordshaker/jesswhite/security/code-scanning/3](https://github.com/wordshaker/jesswhite/security/code-scanning/3)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and builds documentation, it likely only needs `contents: read` permission. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the `build` job). The best practice is to set it at the workflow level unless a job needs different permissions. Add the following block after the `name:` and before the `on:` key in `.github/workflows/build.yml`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
