### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: JessWhite Deploy to CO.UK
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/wordshaker/jesswhite/security/code-scanning/4](https://github.com/wordshaker/jesswhite/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow file. The best way is to add it at the root level (just below the `name:` and before `on:`), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, as the workflow only checks out code and does not need to write to the repository or interact with issues or pull requests. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
